### PR TITLE
Add CI and swift-format config

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,24 @@
+name: Pull Requst
+
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Lint Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Formatting
+        run: swift format lint --recursive --strict .
+
+  test-ubuntu-latest:
+    name: Test Swift ${{ matrix.swift }} Ubuntu Latest
+    strategy:
+      matrix:
+        swift: ["6.0", "6.0.1", "6.0.2"]
+    runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Tests
+        run: swift test -Xswiftc -warnings-as-errors -Xcc -Werror

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,24 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentation" : {
+    "spaces" : 4
+  },
+  "indentConditionalCompilationBlocks" : false,
+  "indentSwitchCaseLabels" : true,
+  "lineLength" : 140,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : true,
+    "NeverForceUnwrap" : true,
+    "NeverUseForceTry" : true,
+    "NeverUseImplicitlyUnwrappedOptionals" : true,
+    "NoLeadingUnderscores" : true,
+    "OmitExplicitReturns" : true,
+    "UseEarlyExits" : true,
+    "UseWhereClausesInForLoops" : true,
+    "ValidateDocumentationComments" : true
+  },
+  "spacesAroundRangeFormationOperators" : true,
+  "version" : 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.2")
     ],
     targets: [
         .target(
@@ -28,13 +28,13 @@ let package = Package(
         .target(
             name: "RealModuleDifferentiable",
             dependencies: [
-                .product(name: "RealModule", package: "swift-numerics"),
+                .product(name: "RealModule", package: "swift-numerics")
             ]
         ),
         .testTarget(
             name: "RealModuleDifferentiableTests",
             dependencies: [
-                "RealModuleDifferentiable",
+                "RealModuleDifferentiable"
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # swift-numerics-differentiable
+
+## Contributing
+### Code Formatting
+This package makes use of [swift-format](https://github.com/swiftlang/swift-format), which is built directly into the swift toolchain as of
+swift 6. To apply formatting rules to all files, which you should do before submitting a PR, run from the root of the repository:
+
+```sh
+swift format --in-place --recursive .
+```
+
+Formatting is validated with the `--strict` flag on every PR


### PR DESCRIPTION
Depends on #1

This adds basic CI (linting and tests on macOS/ubuntu) for PRs. Some things to keep in mind: 
* the `.swift-format` file here is opinionated based on my personal preferences, I am happy to tweak them based on other maintainers' thoughts
* By default I've set swift to build with `-Werror` as I think it's a good practice to get into off the starting block. Again, if we forsee unavoidable errors (`@deprecated()` 😡 ) being added, happy to remove those flags
* The macOS tests are running only against the latest stable Xcode - happy to dig into more custom options there if desired