### PR TITLE
fix: add concrete type to prevent compiler error on main due to ambiguous candidates

### DIFF
--- a/Sources/CodeGeneratorExecutable/RealFunctionsDerivativesGenerator.swift
+++ b/Sources/CodeGeneratorExecutable/RealFunctionsDerivativesGenerator.swift
@@ -233,7 +233,7 @@ enum RealFunctionsDerivativesGenerator {
                         "x < 0 ? (value: -x, pullback: { v in .zero - v }) : (value: x, pullback: { v in v })"
                     }
                     else {
-                        "(value: abs(x), pullback: { v in v.replacing(with: -v, where: x .< .zero) })"
+                        "(value: abs(x), pullback: { v in v.replacing(with: -v, where: x .< \(type).zero) })"
                     }
                 }())
             }


### PR DESCRIPTION
This prevents a compiler error when using the newest swift main snapshot