### PR TITLE
chore: prevent potential breakage from numerics release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-numerics", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-numerics", .upToNextMinor(from: "1.0.2")),
     ],
     targets: [
         .executableTarget(name: "CodeGeneratorExecutable"),


### PR DESCRIPTION
1.1 of swift-numerics is about to be released and will drop some differentiable methods we might be depending on. We'll adopt these in this package as soon as the tag is created. To prevent potentially breaking anything for users let's pin the version it to 1.0.2 for now.