### PR TITLE
fix: add import _Differentiation check in stdlib overloads plugin

### DIFF
--- a/Sources/CodeGeneratorExecutable/STDLibOverloadsGenerator.swift
+++ b/Sources/CodeGeneratorExecutable/STDLibOverloadsGenerator.swift
@@ -1,6 +1,7 @@
 enum STDLibOverloadsGenerator {
     static func stdLibOverloadsExtension(floatingPointType: String, simdWidth: Int) -> String {
         """
+        #if canImport(_Differentiation)
         import _Differentiation
 
         extension SIMD\(simdWidth) where Scalar == \(floatingPointType) {
@@ -329,6 +330,7 @@ enum STDLibOverloadsGenerator {
                 a = a / b
             }
         }
+        #endif
         """
     }
 }


### PR DESCRIPTION
We address the build issue on platforms that do not support `import _Differentiation` by adding 

```swift
        #if canImport(_Differentiation)
        import _Differentiation

       // ...

       #endif
```

to the autogenerated `*STDLibOverloads.swift` files