### PR TITLE
fix: only add direct simd overloads when using Swift 6.3 or above.

### DIFF
--- a/Sources/CodeGeneratorExecutable/STDLibOverloadsGenerator.swift
+++ b/Sources/CodeGeneratorExecutable/STDLibOverloadsGenerator.swift
@@ -1,7 +1,7 @@
 enum STDLibOverloadsGenerator {
     static func stdLibOverloadsExtension(floatingPointType: String, simdWidth: Int) -> String {
         """
-        #if canImport(_Differentiation)
+        #if canImport(_Differentiation) && compiler(>=6.3)
         import _Differentiation
 
         extension SIMD\(simdWidth) where Scalar == \(floatingPointType) {


### PR DESCRIPTION
This avoids an issue on 6.2 when compiling in release mode